### PR TITLE
Integrate streamlit app with LeapIDE better

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,14 @@
 tasks:
-  - init: |
+  - name: Run streamlit app
+    init: |
       pip install -r requirements.txt
     command: |
       port=8501
       url=$(gp url "$port")
       host=${url#"https://"}
-      streamlit run --server.port "$port" --browser.serverAddress "$host" --browser.serverPort 80 bin_packing_app.py &
-      gp await-port "$port" && gp preview "$url" --external
+      streamlit run --server.port "$port" --browser.serverAddress "$host" --browser.serverPort 80 bin_packing_app.py
+
+  - name: Open streamlit app in a new browser window
+    command: |
+      port=8501
+      gp await-port "$port" && gp preview "$(gp url "$port")" --external

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,8 @@ tasks:
   - init: |
       pip install -r requirements.txt
     command: |
-      streamlit run --server.port 8501 bin_packing_app.py
-
-ports:
-  - port: 8501
-    onOpen: open-browser
+      port=8501
+      url=$(gp url "$port")
+      host=${url#"https://"}
+      streamlit run --server.port "$port" --browser.serverAddress "$host" --browser.serverPort 80 bin_packing_app.py &
+      gp await-port "$port" && gp preview "$url" --external

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,9 @@
 tasks:
+  - name: Open streamlit app in a new browser window
+    command: |
+      port=8501
+      gp await-port "$port" && gp preview "$(gp url "$port")" --external
+
   - name: Run streamlit app
     init: |
       pip install -r requirements.txt
@@ -7,8 +12,3 @@ tasks:
       url=$(gp url "$port")
       host=${url#"https://"}
       streamlit run --server.port "$port" --browser.serverAddress "$host" --browser.serverPort 80 bin_packing_app.py
-
-  - name: Open streamlit app in a new browser window
-    command: |
-      port=8501
-      gp await-port "$port" && gp preview "$(gp url "$port")" --external

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,6 @@
 [theme]
 base="light"
 font="sans serif"
+
+[browser]
+gatherUsageStats = false


### PR DESCRIPTION
Namely:
- print out a relevant URL on app start (one that can be opened by user)
- notify user with a popup then app starts (so they can open the webpage
  explicitly)
- try opening the app in a new browser window, in case UA doesn't block
  popups

Close #24.
Fix #25.
Fix #27.