### PR TITLE
Upgrade `streamlit` to fix a dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dwave-ocean-sdk>=6.3.0
 mip==1.13.0
 plotly==5.6.0
-streamlit==1.9.2
+streamlit==1.22.0
 tabulate==0.8.9


### PR DESCRIPTION
Streamlit's dependency, `altair` was unpinned/unbounded in previous versions, causing an issue with a major upgrade of altair just released (version 5.0.0).