### PR TITLE
Add ecommerce carton sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ typing:
     python packing3d.py --data_filepath <path to your problem file>
 
 There are several examples of problem instances under the `input` folder.
+The file `input/sample_data_ecommerce_cartons.txt` provides a small
+ecommerce-carton instance using the 24x10x8 carton dimensions from the public
+[Packrift packaging optimization benchmark corpus][packrift-corpus].
 
 ### Inputs
 
@@ -337,6 +340,8 @@ for the height constraints, however, here we want to track the bin height `s_j`.
 [1] Martello, Silvano, David Pisinger, and Daniele Vigo.
 "The three-dimensional bin packing problem."
 Operations research 48.2 (2000): 256-267.
+
+[packrift-corpus]: https://github.com/Packrift/packaging-optimization-benchmark-corpus/blob/main/examples/ortools-carton-selection/sample_cartons.csv
 
 ## License
 

--- a/input/sample_data_ecommerce_cartons.txt
+++ b/input/sample_data_ecommerce_cartons.txt
@@ -1,0 +1,9 @@
+# Max num of bins : 2
+# Bin dimensions (L * W * H): 24 10 8
+
+  case_id    quantity    length    width    height
+---------  ----------  --------  -------  --------
+0          2           10        6        2
+1          3           8         4        3
+2          2           12        5        4
+3          1           16        6        4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,22 @@ class TestUtils(unittest.TestCase):
         )
         self.assertEqual(data1, data)
 
+    def test_read_ecommerce_carton_sample(self):
+        data = read_instance(instance_path=project_dir + "/input/sample_data_ecommerce_cartons.txt")
+
+        self.assertEqual(
+            data,
+            {
+                "Case ID": [0, 1, 2, 3],
+                "Quantity": [2, 3, 2, 1],
+                "Length": [10, 8, 12, 16],
+                "Width": [6, 4, 5, 6],
+                "Height": [2, 3, 4, 4],
+                "num_bins": 2,
+                "bin_dimensions": [24, 10, 8],
+            },
+        )
+
     def test_write_solution_to_file(self):
         data = read_instance(instance_path=project_dir + "/tests/test_data_1.txt")
         cases = Cases(data)


### PR DESCRIPTION
## Summary

Adds a small ecommerce-carton input instance and a parser test for it. The sample follows the existing text input format and gives the demo one more concrete case with multiple item quantities and a two-bin cap.

## Notes

- `input/sample_data_ecommerce_cartons.txt` uses 24x10x8 carton dimensions from a static public ecommerce packaging corpus sample.
- The fixture stays intentionally small so it can be used for parser/model setup checks without requiring a cloud solver run.
- Attribution/source: https://github.com/Packrift/packaging-optimization-benchmark-corpus/blob/main/examples/ortools-carton-selection/sample_cartons.csv

## Testing

- `git diff --check`
- Parsed `input/sample_data_ecommerce_cartons.txt` locally with a small standalone Python check matching the expected rows.
- Full test suite not run locally: this environment does not have the repository's Python dependencies installed (`dimod` is missing).
